### PR TITLE
Add workflow status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Model Service
 
+[![CI/CD Pipeline For Luigi Scheduler](https://github.com/pebrisulistiyo/model-service/actions/workflows/workflow-scheduler.yml/badge.svg)](https://github.com/pebrisulistiyo/model-service/actions/workflows/workflow-scheduler.yml)
+[![CI/CD Pipeline For Luigi Wrapper](https://github.com/pebrisulistiyo/model-service/actions/workflows/workflow-wrapper.yml/badge.svg)](https://github.com/pebrisulistiyo/model-service/actions/workflows/workflow-wrapper.yml)
+[![Model Training Pipeline](https://github.com/pebrisulistiyo/model-service/actions/workflows/model-training.yml/badge.svg)](https://github.com/pebrisulistiyo/model-service/actions/workflows/model-training.yml)
+
 A machine learning model service with data processing and training pipelines.
 
 ## Setup


### PR DESCRIPTION
## Summary
- add GitHub Actions badges for scheduler, wrapper, and model training workflows in README

## Testing
- `pip install -r requirements-dev.txt` (fails: Tunnel connection failed)
- `pytest` (fails: unrecognized arguments --cov*)

------
https://chatgpt.com/codex/tasks/task_e_689cadc637d48327b49a355b192487f6